### PR TITLE
Add missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 
 # Install the required packages
 RUN \
-  apt-get install -y git dialog libswitch-perl libwww-perl python-twisted python-crypto python-pyasn1 python-gmpy2 python-zope.interface python-pip python-gmpy python-gmpy2 mysql-client randomsound rng-tools python-mysqldb curl openssh-server unzip debconf debconf-utils logrotate
+  apt-get install -y git dialog libswitch-perl libwww-perl python-twisted python-crypto python-pyasn1 python-gmpy2 python-zope.interface python-pip python-gmpy python-gmpy2 python-requests mysql-client randomsound rng-tools python-mysqldb curl openssh-server unzip debconf debconf-utils logrotate sudo
 
 # Clone the DShield software
 RUN \


### PR DESCRIPTION
Probably because `FROM ubuntu` points to most recent version and 16.04 is out, build stopped working because of lack of sudo which is now not installed by default.
Also added `python-requests`, without it build succeeds but cowrie fails to start.
